### PR TITLE
0.55 - regional buckets, multipart-upload tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,28 @@
+Mon Jul 18 16:27:41 2022  Rob Lauer  <rlauer6@comcast.net>
+
+	[0.55 - regional buckets]:
+	* NEWS.md: new
+	* src/main/perl/lib/Amazon/S3/Constants.pm.in
+	- + $MIN_MULTIPART_UPLOAD_CHUNK_SIZE
+	* src/main/perl/lib/Amazon/S3.pm.in
+	- document Signature V4 changes/implications
+	- use new Amazon::S3::Signature::V4 object
+	(_make_request): accept hash ref as argument
+	(get_bucket_location): new
+	(reset_signer_region): new
+	* src/main/perl/lib/Amazon/S3/Bucket.pm.in
+	- document multipart methods
+	- send region in all _make_request calls
+	(_send_request): check if arg is a request
+	(new)
+	- accept region argument
+	- set bucket region if region not passed
+	(upload_multipart_object): new
+	* src/main/perl/lib/Amazon/S3/Signature/V4: new
+	* src/main/perl/lib/Makefile.am: add above to build
+	* src/main/perl/t/05-multpart-upload.t: new
+	* src/main/perl/t/06-list-multpart-upload.t: new
+
 Thu Jul 14 06:34:56 2022  Rob Lauer  <rlauer6@comcast.net>>
 
 	[0.55 - use XML::LibXML]:
@@ -19,7 +44,7 @@ Thu Jul 14 06:34:56 2022  Rob Lauer  <rlauer6@comcast.net>>
 	- set default region to caller's value or default
 	(buckets): set region to us-east-1 temporarily
 	(debug): new convenience method for level => 'debug'
-	(_make_request): allow disabling of domain buckets 
+	(_make_request): allow disabling of domain buckets
 	* src/main/perl/lib/Amazon/S3/Bucket.pm.in: comment tweak
 	* src/main/perl/lib/Amazon/S3/Constant.pm.in: $DOT
 	* src/main/perl/t/01-api.t: set $dns_bucket_names to true?

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,20 @@
+# NEWS
+
+This is the `NEWS` file for the `perl-Amazon-S3`
+project. This file contains information on changes since the last
+release of the package, as well as a running list of changes from
+previous versions.  If critical bugs are found in any of the software,
+notice of such bugs and the versions in which they were fixed will be
+noted here, as well.
+
+# perl-Amazon-S3 0.55 (2022-07-18)
+
+## Enhancements
+
+* new convenience method for multipart upload - `upload_multipart_object()`
+* new convenience method for retrieving bucket region - `get_bucket_location()`
+* buckets objects carry region attribute to facilitate signing
+* multipart upload unit tests
+
+## Fixes
+

--- a/src/main/perl/lib/Amazon/S3.pm.in
+++ b/src/main/perl/lib/Amazon/S3.pm.in
@@ -8,6 +8,7 @@ use 5.010;
 use Amazon::S3::Bucket;
 use Amazon::S3::Constants qw{:all};
 use Amazon::S3::Logger;
+use Amazon::S3::Signature::V4;
 
 use Carp;
 use Data::Dumper;
@@ -21,8 +22,6 @@ use Scalar::Util qw{ reftype blessed };
 use List::Util qw{ any };
 use URI::Escape qw{uri_escape_utf8};
 use XML::LibXML::Simple qw{XMLin};
-
-use Net::Amazon::Signature::V4;
 
 use parent qw{Class::Accessor::Fast};
 
@@ -215,6 +214,20 @@ sub new {
 }
 
 ########################################################################
+sub get_bucket_location {
+########################################################################
+  my ( $self, $bucket ) = @_;
+
+  my $region;
+
+  if ( !ref $bucket || ref $bucket !~ /Amazon::S3::Bucket/xsm ) {
+    $bucket = Amazon::S3::Bucket->new( bucket => $bucket, account => $self );
+  }
+
+  return $self->get_location_constraint // 'us-east-1';
+}
+
+########################################################################
 sub get_default_region {
 ########################################################################
   my ($self) = @_;
@@ -341,16 +354,7 @@ sub buckets {
   # temporarily cache signer
   my $region = $self->_region;
 
-  if ( $self->cache_signer ) {
-    if ( ref $self->signer =~ /Net::Amazon::Signature::V4/xsm ) {
-      if ( $self->region ne 'us-east-1' ) {
-        $self->signer->{endpoint} = 'us-east-1';
-      }
-    }
-  }
-  else {
-    $self->region('us-east-1');
-  }
+  $self->reset_signer_region('us-east-1'); # default region for buckets op
 
   my $r = $self->_send_request( 'GET', $EMPTY, {} );
 
@@ -381,15 +385,7 @@ sub buckets {
     } ## end foreach my $node ( @{$buckets...})
   } ## end if ( ref $r->{Buckets})
 
-  # reset region
-  if ( $self->cache_signer ) {
-    if ( $self->region && $self->region ne 'us-east-1' ) {
-      $self->signer->{endpoint} = $region;
-    }
-  }
-  else {
-    $self->region($region);
-  }
+  $self->reset_signer_region($region); # restore original region
 
   return {
     owner_id          => $owner_id,
@@ -397,6 +393,28 @@ sub buckets {
     buckets           => \@buckets,
   };
 } ## end sub buckets
+
+########################################################################
+sub reset_signer_region {
+########################################################################
+  my ( $self, $region ) = @_;
+
+  # reset signer's region, if the region wasn't us-east-1...note this
+  # is probably not needed anymore since bucket operations now send
+  # the region of the bucket to the signer
+  if ( $self->cache_signer ) {
+    if ( $self->region && $self->region ne 'us-east-1' ) {
+      if ( $self->signer->can('region') ) {
+        $self->signer->region($region);
+      }
+    }
+  }
+  else {
+    $self->region($region);
+  }
+
+  return $self->region;
+}
 
 ########################################################################
 sub add_bucket {
@@ -673,10 +691,10 @@ sub signer {
 
   my $creds = $self->credentials ? $self->credentials : $self;
 
-  my $signer = Net::Amazon::Signature::V4->new(
+  my $signer = Amazon::S3::Signature::V4->new(
     { access_key_id => $creds->get_aws_access_key_id,
       secret        => $creds->get_aws_secret_access_key,
-      endpoint      => $self->region || $self->get_default_region,
+      region        => $self->region || $self->get_default_region,
       service       => 's3',
       $self->get_token ? ( security_token => $creds->get_token ) : (),
     }
@@ -732,8 +750,18 @@ sub _can_bucket_be_subdomain {
 sub _make_request {
 ########################################################################
   my ( $self, @args ) = @_;
+  my ( $method, $path, $headers, $data, $metadata, $region );
 
-  my ( $method, $path, $headers, $data, $metadata ) = @args;
+  if ( ref $args[0] && reftype( $args[0] ) eq 'HASH' ) {
+    ( $method, $path, $headers, $data, $metadata, $region )
+      = @{ $args[0] }{qw{method path headers data metadata region}};
+  }
+  else {
+    ( $method, $path, $headers, $data, $metadata, $region ) = @args;
+  }
+
+  # reset region on every call...every bucket can have it's own region
+  $self->region( $region // $self->_region );
 
   croak 'must specify method'
     if !$method;
@@ -768,6 +796,7 @@ sub _make_request {
 
   $request->content($data);
 
+  $self->signer->{endpoint} = $region; # always set regional endpoint for signing
   $self->signer->sign($request);
 
   $self->get_logger->trace( sub { return Dumper( [$request] ); } );
@@ -782,11 +811,18 @@ sub _send_request {
 ########################################################################
   my ( $self, @args ) = @_;
 
-  my $request = @args == 1 ? $args[0] : $self->_make_request(@args);
+  my $request;
+
+  if ( @args == 1 && ref $args[0] =~ /HTTP::Request/xsm ) {
+    $request = $args[0];
+  }
+  else {
+    $request = $self->_make_request(@args);
+  }
 
   my $response = $self->_do_http($request);
 
-  $self->get_logger->trace( Dumper( [$response] ) );
+  $self->get_logger->debug( Dumper( [$response] ) );
 
   $self->last_response($response);
 
@@ -1370,52 +1406,60 @@ via L<XML::Simple>.
 
 =back
 
-=head1 LIMITATIONS
+=head1 LIMITATIONS AND DIFFERENCES WITH EARLIER VERSIONS
 
 As noted this module is no longer a I<drop-in> replacement for
-C<Net::Amazon::S3> and has limitations that may make the use of this
-module in your applications questionable. The list of limitations
-below may not be complete.
+C<Net::Amazon::S3> and has limitations and differences that may make the use of this
+module in your applications questionable.
 
 =over 5
 
 =item * API Signing
 
-I<Update: versions >= 0.54 now support Signature V4>
-
 Making calls to AWS APIs requires that the calls be signed.  Amazon
 has added a new signing method (Signature Version 4) to increase
-security around their APIs.  This module continues to use the original
-signing method (Signature Version 2).
+security around their APIs. This module no longer utilizes Signature
+Version V2.
 
 B<New regions after January 30, 2014 will only support Signature Version 4.>
 
-There has been some effort to add support of Signature Version 4
-however several method in this package may need significant
-refactoring and testing in order to support the new sigining method.
+See L</Signature Version V4> below for important details.>
 
 =over 10
-
-=item Signature Version 2
-
-L<https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html>
 
 =item Signature Version 4
 
 L<https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html>
 
+I<IMPORTANT NOTE:>
+
+Unlike Signature Version 2, Version 4 requires a regional
+parameter. This implies that you need to supply the bucket's region
+when signing requests for any API call that involve a specific
+bucket. Starting with version 0.55 of this module,
+C<Amazon::S3::Bucket> will have a new method (C<region()> and accept
+in the constructor a C<region> parameter.  If one is not supplied, the
+region for the bucket will be determined for you by calling the
+C<get_location_constraint()> method.
+
+When signing API calls, the region for the specific bucket will be
+used. For calls that are not regional (C<buckets()>, e.g.) the default
+region sent in the C<Amazon::S3> constructor will be used.
+
+=item Signature Version 2
+
+L<https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html>
+
 =back
 
 =item * New APIs
 
-This module does not support the myriad of new API method calls
+This module does not support some of the new API method calls
 available for S3 since its original creation.
 
 =item * Multipart Upload Support
 
-While there are undocumented methods for multi-part uploads (used for
-files >5Gb), those methods have not been tested and may not in fact
-work today.
+There are currently no unit tests for multipart uploads.
 
 For more information regarding multi-part uploads visit the link below.
 
@@ -1591,13 +1635,6 @@ storing your credentials and preventing exfiltration.
 =back
 
 
-=head2 turn_on_special_retry
-
-Called to add extra retry codes if retry has been set
-
-=head2 turn_off_special_retry
-
-Called to turn off special retry codes when we are deliberately triggering them
 
 =head2 adjust_region
 
@@ -1790,6 +1827,26 @@ Each key is a HASHREF that looks like this:
         owner_displayname => $owner_name
     }
 
+=head2 get_bucket_location
+
+ get_bucket_location(bucket-name)
+ get_bucket_locaiton(bucket-obj)
+
+This is a convenience routines for the C<get_location_constraint()> of
+the bucket object.  This method will, however return the default
+region of 'us-east-1' when C<get_location_constraint()> returns a null
+value.
+
+ my $region = $s3->get_bucket_location('my-bucket');
+
+Starting with version 0.55, C<Amazon::S3::Bucket> will call this
+C<get_location_constraint()> to determine the region for the
+bucket. You can get the region for the bucket by using the C<region()>
+method of the bucket object.
+
+  my $bucket = $s3->bucket('my-bucket');
+  my $bucket_region = $bucket->region;
+
 =head2 get_logger
 
 Returns the logger object. If you did not set a logger when you
@@ -1823,6 +1880,14 @@ Returns the last L<HTTP::Request> object.
 Set the logging level.
 
 default: error
+
+=head2 turn_on_special_retry
+
+Called to add extra retry codes if retry has been set
+
+=head2 turn_off_special_retry
+
+Called to turn off special retry codes when we are deliberately triggering them
 
 =head1 ABOUT
 

--- a/src/main/perl/lib/Amazon/S3/Bucket.pm.in
+++ b/src/main/perl/lib/Amazon/S3/Bucket.pm.in
@@ -12,7 +12,9 @@ use Digest::MD5::File qw(file_md5 file_md5_hex);
 use English qw{-no_match_vars};
 use File::stat;
 use IO::File;
+use IO::Scalar;
 use MIME::Base64;
+use Scalar::Util qw{reftype};
 use XML::LibXML;
 use URI;
 
@@ -20,7 +22,8 @@ use parent qw{Class::Accessor::Fast};
 
 our $VERSION = '@PACKAGE_VERSION@'; ## no critic
 
-__PACKAGE__->mk_accessors(qw{bucket creation_date account buffer_size});
+__PACKAGE__->mk_accessors(
+  qw{bucket creation_date account buffer_size region});
 
 ########################################################################
 sub new {
@@ -37,6 +40,16 @@ sub new {
 
   croak 'no account'
     if !$self->account;
+
+  # now each bucket maintains its own region
+  if ( !$self->region ) {
+    my $region = $self->get_location_constraint() // 'us-east-1';
+
+    $self->account->get_logger->debug( sprintf "bucket: %s region: %s\n",
+      $self->bucket, ( $region // $EMPTY ) );
+
+    $self->region($region);
+  }
 
   return $self;
 } ## end sub new
@@ -120,12 +133,125 @@ sub add_key_filename {
   return $self->add_key( $key, \$value, $conf );
 } ## end sub add_key_filename
 
+########################################################################
+sub upload_multipart_object {
+########################################################################
+  my ( $self, @args ) = @_;
+
+  my $logger = $self->account->get_logger;
+
+  my %parameters;
+
+  if ( @args == 1 && reftype( $args[0] ) eq 'HASH' ) {
+    %parameters = %{ $args[0] };
+  }
+  else {
+    %parameters = @args;
+  }
+
+  croak 'no key!'
+    if !$parameters{key};
+
+  croak 'either data, callback or fh must be set!'
+    if !$parameters{data} && !$parameters{callback} && !$parameters{fh};
+
+  croak 'callback must be a reference to a subroutine!'
+    if $parameters{callback} && reftype( $parameters{callback} ) ne 'CODE';
+
+  $parameters{abort_on_error} //= $TRUE;
+  $parameters{chunk_size}     //= $MIN_MULTIPART_UPLOAD_CHUNK_SIZE;
+
+  if ( !$parameters{callback} && !$parameters{fh} ) {
+    #...but really nobody should be passing a >5MB scalar
+    my $data = ref $parameters{data} ? $parameters{data} : \$parameters{data};
+
+    $parameters{fh} = IO::Scalar->new($data);
+  }
+
+  # ...having a file handle implies, we use this callback
+  if ( $parameters{fh} ) {
+    my $fh = $parameters{fh};
+
+    $fh->seek( 0, 2 );
+
+    my $length = $fh->tell;
+    $fh->seek( 0, 0 );
+
+    $logger->debug( sub { return sprintf 'length of object: %s', $length; } );
+
+    croak 'length of the object must be >= '
+      . $MIN_MULTIPART_UPLOAD_CHUNK_SIZE
+      if $length < $MIN_MULTIPART_UPLOAD_CHUNK_SIZE;
+
+    my $chunk_size
+      = ( $parameters{chunk_size} && $parameters{chunk_size} )
+      > $MIN_MULTIPART_UPLOAD_CHUNK_SIZE
+      ? $parameters{chunk_size}
+      : $MIN_MULTIPART_UPLOAD_CHUNK_SIZE;
+
+    $parameters{callback} = sub {
+      return
+        if !$length;
+
+      my $bytes_read = 0;
+
+      my $n = $length >= $chunk_size ? $chunk_size : $length;
+
+      $logger->debug( sprintf 'reading %d bytes', $n );
+
+      my $buffer;
+
+      my $bytes = $fh->read( $buffer, $n, $bytes_read );
+      $logger->debug( sprintf 'read %d bytes', $bytes );
+
+      $bytes_read += $bytes;
+
+      $length -= $bytes;
+
+      $logger->debug( sprintf '%s bytes left to read', $length );
+
+      return ( \$buffer, $bytes );
+    };
+
+  }
+
+  my $headers = $parameters{headers} || {};
+
+  my $id = $self->initiate_multipart_upload( $parameters{key}, $headers );
+
+  $logger->debug( sprintf 'multipart id: %s', $id );
+
+  my $part = 1;
+  my %parts;
+  my $key = $parameters{key};
+
+  eval {
+    while (1) {
+      my ( $buffer, $length ) = $parameters{callback}->();
+      last if !$buffer;
+
+      my $etag = $self->upload_part_of_multipart_upload(
+        { id => $id, key => $key, data => $buffer, part => $part } );
+
+      $parts{ $part++ } = $etag;
+    }
+
+    $self->complete_multipart_upload( $parameters{key}, $id, \%parts );
+  };
+
+  if ( $EVAL_ERROR && $parameters{abort_on_error} ) {
+    $self->abort_multipart_upload( $key, $id );
+    %parts = ();
+  }
+
+  return \%parts;
+}
+
 # Initiates a multipart upload operation. This is necessary for uploading
 # files > 5Gb to Amazon S3
 #
 # returns: upload ID assigned by Amazon (used to identify this
 # particular upload in other operations)
-
 ########################################################################
 sub initiate_multipart_upload {
 ########################################################################
@@ -136,8 +262,14 @@ sub initiate_multipart_upload {
 
   my $acct = $self->account;
 
-  my $request
-    = $acct->_make_request( 'POST', $self->_uri($key) . '?uploads=', $conf );
+  my $request = $acct->_make_request(
+    { region  => $self->region,
+      method  => 'POST',
+      path    => $self->_uri($key) . '?uploads=',
+      headers => $conf
+    }
+  );
+
   my $response = $acct->_do_http($request);
 
   $acct->_croak_if_response_error($response);
@@ -160,7 +292,27 @@ sub upload_part_of_multipart_upload {
 ########################################################################
   my ( $self, @args ) = @_;
 
-  my ( $key, $upload_id, $part_number, $data, $length ) = @args;
+  my ( $key, $upload_id, $part_number, $data, $length );
+
+  if ( @args == 1 ) {
+    if ( reftype( $args[0] ) eq 'HASH' ) {
+      ( $key, $upload_id, $part_number, $data, $length )
+        = @{ $args[0] }{qw{ key id part data length}};
+    }
+    elsif ( reftype( $args[0] ) eq 'ARRAY' ) {
+      ( $key, $upload_id, $part_number, $data, $length ) = @{ $args[0] };
+    }
+  }
+  else {
+    ( $key, $upload_id, $part_number, $data, $length ) = @args;
+  }
+
+  # argh...wish we didn't have to do this!
+  if ( ref $data ) {
+    $data = ${$data};
+  }
+
+  $length = $length || length $data;
 
   croak 'Object key is required'
     if !$key;
@@ -183,9 +335,19 @@ sub upload_part_of_multipart_upload {
   $conf->{'Content-Length'} = $length;
 
   my $params = "?partNumber=${part_number}&uploadId=${upload_id}";
-  my $request
-    = $acct->_make_request( 'PUT', $self->_uri($key) . $params, $conf,
-    $data );
+
+  $self->account->get_logger->debug(
+    'uploading ' . sprintf 'part: %s length: %s',
+    $part_number, length $data );
+
+  my $request = $acct->_make_request(
+    { region  => $self->region,
+      method  => 'PUT',
+      path    => $self->_uri($key) . $params,
+      headers => $conf,
+      data    => $data
+    }
+  );
 
   my $response = $acct->_do_http($request);
 
@@ -211,6 +373,9 @@ sub upload_part_of_multipart_upload {
 sub complete_multipart_upload {
 ########################################################################
   my ( $self, $key, $upload_id, $parts_hr ) = @_;
+
+  $self->account->get_logger->debug(
+    Dumper( [ $key, $upload_id, $parts_hr ] ) );
 
   croak 'Object key is required'
     if !$key;
@@ -239,7 +404,10 @@ sub complete_multipart_upload {
     $root_element->addChild($part);
   } ## end foreach my $part_num ( sort...)
 
-  my $content    = $xml_doc->toString;
+  my $content = $xml_doc->toString;
+
+  $self->account->get_logger->debug("content: \n$content");
+
   my $md5        = md5($content);
   my $md5_base64 = encode_base64($md5);
   chomp $md5_base64;
@@ -250,13 +418,26 @@ sub complete_multipart_upload {
     'Content-Type'   => 'application/xml'
   };
 
-  my $acct    = $self->account;
-  my $params  = "?uploadId=${upload_id}";
-  my $request = $acct->_make_request( 'POST', $self->_uri($key) . $params,
-    $conf, $content );
+  my $acct   = $self->account;
+  my $params = "?uploadId=${upload_id}";
+
+  my $request = $acct->_make_request(
+    { region  => $self->region,
+      method  => 'POST',
+      path    => $self->_uri($key) . $params,
+      headers => $conf,
+      data    => $content
+    }
+  );
+
   my $response = $acct->_do_http($request);
 
-  $acct->_croak_if_response_error($response);
+  $acct->get_logger->debug( Dumper($response) );
+
+  if ( $response->code !~ /\A2\d\d\z/xsm ) {
+    $acct->_remember_errors( $response->content, 1 );
+    croak $response->status_line;
+  }
 
   return $TRUE;
 } ## end sub complete_multipart_upload
@@ -275,9 +456,16 @@ sub abort_multipart_upload {
   croak 'Upload id is required'
     if !$upload_id;
 
-  my $acct    = $self->account;
-  my $params  = "?uploadId=${upload_id}";
-  my $request = $acct->_make_request( 'DELETE', $self->_uri($key) . $params );
+  my $acct   = $self->account;
+  my $params = "?uploadId=${upload_id}";
+
+  my $request = $acct->_make_request(
+    { region => $self->region,
+      method => 'DELETE',
+      path   => $self->_uri($key) . $params
+    }
+  );
+
   my $response = $acct->_do_http($request);
 
   $acct->_croak_if_response_error($response);
@@ -302,8 +490,14 @@ sub list_multipart_upload_parts {
 
   my $acct   = $self->account;
   my $params = "?uploadId=${upload_id}";
-  my $request
-    = $acct->_make_request( 'GET', $self->_uri($key) . $params, $conf );
+
+  my $request = $acct->_make_request(
+    { region  => $self->region,
+      method  => 'GET',
+      path    => $self->_uri($key) . $params,
+      headers => $conf
+    }
+  );
 
   my $response = $acct->_do_http($request);
 
@@ -323,8 +517,14 @@ sub list_multipart_uploads {
   my ( $self, $conf ) = @_;
 
   my $acct = $self->account;
-  my $request
-    = $acct->_make_request( 'GET', $self->_uri() . '?uploads', $conf );
+
+  my $request = $acct->_make_request(
+    { region  => $self->region,
+      method  => 'GET',
+      path    => $self->_uri() . '?uploads',
+      headers => $conf
+    }
+  );
 
   my $response = $acct->_do_http($request);
 
@@ -357,7 +557,13 @@ sub get_key {
 
   my $uri = $self->_uri($key);
 
-  my $request = $acct->_make_request( $method, $uri, {} );
+  my $request = $acct->_make_request(
+    { region  => $self->region,
+      method  => $method,
+      path    => $uri,
+      headers => {}
+    }
+  );
 
   my $response = $acct->_do_http( $request, $filename );
 
@@ -502,8 +708,13 @@ sub get_acl {
 
   my $acct = $self->account;
 
-  my $request
-    = $acct->_make_request( 'GET', $self->_uri($key) . '?acl=', {} );
+  my $request = $acct->_make_request(
+    { region  => $self->region,
+      method  => 'GET',
+      path    => $self->_uri($key) . '?acl=',
+      headers => {}
+    }
+  );
 
   my $old_redirectable = $acct->ua->requests_redirectable;
   $acct->ua->requests_redirectable( [] );
@@ -517,7 +728,13 @@ sub get_acl {
     my $old_host = $acct->host;
     $acct->host( $uri->host );
 
-    my $request = $acct->_make_request( 'GET', $uri->path, {} );
+    my $request = $acct->_make_request(
+      { region  => $self->region,
+        method  => 'GET',
+        path    => $uri->path,
+        headers => {}
+      }
+    );
 
     $response = $acct->_do_http($request);
 
@@ -563,8 +780,12 @@ sub get_location_constraint {
 ########################################################################
   my ($self) = @_;
 
-  my $xpc
-    = $self->account->_send_request( 'GET', $self->bucket . '/?location=' );
+  my $xpc = $self->account->_send_request(
+    { region => $self->region,
+      method => 'GET',
+      path   => $self->bucket . '/?location='
+    }
+  );
 
   if ( !$xpc ) {
     $self->account->_remember_errors($xpc);
@@ -652,6 +873,8 @@ sub _content_sub {
 1;
 
 __END__
+
+=pod
 
 =head1 NAME
 
@@ -832,30 +1055,6 @@ hood.
 See L<Amazon::S3/list_bucket_all_v2> for documentation of this
 method.
 
-=head2 abort_multipart_upload
-
-Abort a multipart upload
-
-=head2 complete_multipart_upload
-
-Signal completion of a multipart upload
-
-=head2 initiate_multipart_upload
-
-Initiate a multipart upload
-
-=head2 list_multipart_upload_parts
-
-List all the uploaded parts of a multipart upload
-
-=head2 list_multipart_uploads
-
-List multipart uploads in progress
-
-=head2 upload_part_of_multipart_upload
-
-Upload a portion of a multipart upload
-
 =head2 get_acl
 
 Retrieves the Access Control List (ACL) for the bucket or
@@ -941,6 +1140,157 @@ The S3 error code for the last error the account encountered.
 =head2 errstr
 
 A human readable error string for the last error the account encountered.
+
+=head1 MULTIPART UPLOAD SUPPORT
+
+From Amazon's website:
+
+I<Multipart upload allows you to upload a single object as a set of
+parts. Each part is a contiguous portion of the object's data. You can
+upload these object parts independently and in any order. If
+transmission of any part fails, you can retransmit that part without
+affecting other parts. After all parts of your object are uploaded,
+Amazon S3 assembles these parts and creates the object. In general,
+when your object size reaches 100 MB, you should consider using
+multipart uploads instead of uploading the object in a single
+operation.>
+
+See L<https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html> for more information about multipart uploads.
+
+=over 5
+
+=item * Maximum object size 5TB
+
+=item * Maximum number of parts 10,000
+
+=item * Part numbers 1 to 10,000 (inclusive)
+
+=item * Part size 5MB to 5GB. There is no limit on the last part of your multipart upload.
+
+=item * Maximum nubmer of parts returned for a list parts request - 1000
+
+=item * Maximum number of multipart uploads returned in a list multipart uploads request - 1000
+
+=back
+
+A multipart upload begins by calling
+C<initiate_multipart_upload()>. This will return an identifier that is
+used in subsequent calls.
+
+ my $bucket = $s3->bucket('my-bucket');
+ my $id = $bucket->initiate_multipart_upload('some-big-object');
+
+ my $part_list = {};
+
+ my $part = 1;
+ my $etag = $bucket->upload_part_of_multipart_upload('my-bucket', $id, $part, $data, length $data);
+ $part_list{$part++} = $etag;
+
+ $bucket->complete_multipart_upload('my-bucket', $id, $part_list);
+
+=heads upload_multipart_object
+
+ upload_multipart_object( ... )
+
+Convenience routine C<upload_multipart_object> that encapsulates the
+multipart upload process. Accepts a hash or hash reference of
+arguments. If successful, a reference to a hash that contains the part
+numbers and etags of the uploaded parts.
+
+You can pass a data object, callback routine or a file handle.
+
+=over 5
+
+=item key
+
+Name of the key to create.
+
+=item data
+
+Scalar object that contains the data to write to S3.
+
+=item callback
+
+Optionally provided a callback routine that will be called until you
+pass a buffer with a length of 0. Your callback will receive no
+arguments but should return a tuple consisting of a B<reference> to a
+scalar object that contains the data to write and a scalar that
+represents the length of data. Once you return a zero length buffer
+the multipart process will be completed.
+
+=item fh
+
+File handle of an open file. The file must be greater than the minimum
+chunk size for multipart uploads otherwise the method will throw an
+exception.
+
+=item abort_on_error
+
+Indicates whether the multipart upload should be aborted if an error
+is encountered. Amazon will charge you for the storage of parts that
+have been uploaded unless you abort the upload.
+
+default: true
+
+=back
+
+=head2 abort_multipart_upload
+
+ abort_multipart_upload(key, multpart-upload-id)
+
+Abort a multipart upload
+
+=head2 complete_multipart_upload
+
+ complete_multipart_upload(key, multpart-upload-id, parts)
+
+Signal completion of a multipart upload. C<parts> is a reference to a
+hash of part numbers and etags.
+
+=head2 initiate_multipart_upload
+
+ initiate_multipart_upload(key, headers)
+
+Initiate a multipart upload. Returns an id used in subsequent call to
+C<upload_part_of_multipart_upload()>.
+
+=head2 list_multipart_upload_parts
+
+List all the uploaded parts of a multipart upload
+
+=head2 list_multipart_uploads
+
+List multipart uploads in progress
+
+=head2 upload_part_of_multipart_upload
+
+  upload_part_of_multipart_upload(key, id, part, data, length)
+
+Upload a portion of a multipart upload
+
+=over 5
+
+=item key
+
+Name of the key in the bucket to create.
+
+=item id
+
+The multipart-upload id return in the C<initiate_multipart_upload> call.
+
+=item part
+
+The next part number (part numbers start at 1).
+
+=item data
+
+Scalar or reference to a scalar that contains the data to upload.
+
+=item length (optional)
+
+Length of the data.
+
+=back
 
 =head1 SEE ALSO
 

--- a/src/main/perl/lib/Amazon/S3/Constants.pm.in
+++ b/src/main/perl/lib/Amazon/S3/Constants.pm.in
@@ -10,15 +10,17 @@ use Readonly;
 our $VERSION = '@PACKAGE_VERSION@';
 
 # defaults
-Readonly our $AMAZON_HEADER_PREFIX   => 'x-amz-';
-Readonly our $DEFAULT_BUFFER_SIZE    => 4 * 1024;
-Readonly our $DEFAULT_HOST           => 's3.amazonaws.com';
-Readonly our $DEFAULT_TIMEOUT        => 30;
-Readonly our $KEEP_ALIVE_CACHESIZE   => 0;
-Readonly our $METADATA_PREFIX        => 'x-amz-meta-';
-Readonly our $MAX_BUCKET_NAME_LENGTH => 64;
-Readonly our $MIN_BUCKET_NAME_LENGTH => 3;
-Readonly our $DEFAULT_LOG_LEVEL      => 'error';
+Readonly our $AMAZON_HEADER_PREFIX            => 'x-amz-';
+Readonly our $DEFAULT_BUFFER_SIZE             => 4 * 1024;
+Readonly our $DEFAULT_HOST                    => 's3.amazonaws.com';
+Readonly our $DEFAULT_TIMEOUT                 => 30;
+Readonly our $KEEP_ALIVE_CACHESIZE            => 0;
+Readonly our $METADATA_PREFIX                 => 'x-amz-meta-';
+Readonly our $MAX_BUCKET_NAME_LENGTH          => 64;
+Readonly our $MIN_BUCKET_NAME_LENGTH          => 3;
+Readonly our $MIN_MULTIPART_UPLOAD_CHUNK_SIZE => 5 * 1024 * 1024;
+Readonly our $DEFAULT_LOG_LEVEL               => 'error';
+
 Readonly::Hash our %LOG_LEVELS => (
   trace => 5,
   debug => 4,
@@ -75,6 +77,7 @@ our %EXPORT_TAGS = (
       $DEFAULT_HOST
       $MAX_BUCKET_NAME_LENGTH
       $MIN_BUCKET_NAME_LENGTH
+      $MIN_MULTIPART_UPLOAD_CHUNK_SIZE
     }
   ],
 );

--- a/src/main/perl/lib/Amazon/S3/Signature/V4.pm.in
+++ b/src/main/perl/lib/Amazon/S3/Signature/V4.pm.in
@@ -1,0 +1,42 @@
+package Amazon::S3::Signature::V4;
+
+use strict;
+use warnings;
+
+use parent qw{Net::Amazon::Signature::V4};
+
+########################################################################
+sub new {
+########################################################################
+  my ( $class, @args ) = @_;
+
+  my %options;
+
+  if ( !ref $args[0] ) {
+    @options{qw{access_key_id secret endpoint service}} = @args;
+  }
+  else {
+    %options = %{ $args[0] };
+  }
+
+  my $region = delete $options{region};
+  $options{endpoint} //= $region;
+
+  my $self = $class->SUPER::new( \%options );
+
+  return $self;
+}
+
+########################################################################
+sub region {
+########################################################################
+  my ( $self, @args ) = @_;
+
+  if (@args) {
+    $self->{endpoint} = $args[0];
+  }
+
+  return $self->{endpoint};
+}
+
+1;

--- a/src/main/perl/lib/Makefile.am
+++ b/src/main/perl/lib/Makefile.am
@@ -21,21 +21,28 @@ AMAZON_S3_PERLMODULES = \
     Amazon/S3/Constants.pm.in \
     Amazon/S3/Logger.pm.in
 
+AMAZON_S3_SIGNATURE_PERLMODULES = \
+   Amazon/S3/Signature/V4.pm.in
+
 GPERLMODULES = $(PERLMODULES:.pm.in=.pm)
 
 GAMAZON_PERLMODULES = $(AMAZON_PERLMODULES:.pm.in=.pm)
 GAMAZON_S3_PERLMODULES = $(AMAZON_S3_PERLMODULES:.pm.in=.pm)
+GAMAZON_S3_SIGNATURE_PERLMODULES = $(AMAZON_S3_SIGNATURE_PERLMODULES:.pm.in=.pm)
 
 amazondir = $(perl5libdir)/Amazon
 amazon_s3dir = $(amazondir)/S3
+amazon_s3_signaturedir = $(amazondir)/S3
 
 amazon_DATA = $(GAMAZON_PERLMODULES:pm.in=.pm)
 amazon_s3_DATA = $(GAMAZON_S3_PERLMODULES:pm.in=.pm)
+amazon_s3_signature_DATA = $(GAMAZON_S3_SIGNATURE_PERLMODULES:pm.in=.pm)
 
 dist_noinst_DATA = \
     $(PERLMODULES) \
     $(AMAZON_PERLMODULES) \
-    $(AMAZON_S3_PERLMODULES)
+    $(AMAZON_S3_PERLMODULES) \
+    $(AMAZON_S3_SIGNATURE_PERLMODULES)
 
 @do_subst_command@
 
@@ -50,7 +57,10 @@ PERLINCLUDE = \
    $(PERL5_EXTRA_INCLUDES) \
    -I $(perl5libdir) 
 
-Amazon/S3.pm: Amazon/S3/Constants.pm Amazon/S3/Bucket.pm Amazon/S3/Logger.pm
+Amazon/S3.pm: Amazon/S3/Constants.pm \
+	      Amazon/S3/Bucket.pm \
+	      Amazon/S3/Logger.pm \
+	      Amazon/S3/Signature/V4.pm
 
 Amazon/S3/Bucket.pm: Amazon/S3/Constants.pm
 
@@ -67,5 +77,5 @@ all:
 CLEANFILES = \
    $(GPERLMODULES) \
    $(GAMAZON_PERLMODULES) \
-   $(GAMAZON_S3_PERLMODULES)
-
+   $(GAMAZON_S3_PERLMODULES) \
+   $(GAMAZON_S3_SIGNATURE_PERLMODULES)

--- a/src/main/perl/t/05-multipart-upload.t
+++ b/src/main/perl/t/05-multipart-upload.t
@@ -1,0 +1,228 @@
+#!/usr/bin/perl -w
+
+## no critic
+
+use warnings;
+use strict;
+
+use lib 'lib';
+
+use Carp;
+
+use Data::Dumper;
+use Digest::MD5::File qw(file_md5_hex);
+use English qw{-no_match_vars};
+use File::Temp qw{ tempfile };
+use Test::More;
+
+my $host;
+
+if ( exists $ENV{AMAZON_S3_LOCALSTACK} ) {
+  $host = 'localhost:4566';
+
+  $ENV{'AWS_ACCESS_KEY_ID'}     = 'test';
+  $ENV{'AWS_ACCESS_KEY_SECRET'} = 'test';
+
+  $ENV{'AMAZON_S3_EXPENSIVE_TESTS'} = 1;
+
+} ## end if ( exists $ENV{AMAZON_S3_LOCALSTACK...})
+else {
+  $host = $ENV{AMAZON_S3_HOST};
+} ## end else [ if ( exists $ENV{AMAZON_S3_LOCALSTACK...})]
+
+my $secure = $host ? 0 : 1;
+
+# do not use DNS bucket names for testing if a mocking service is used
+# override this by setting AMAZON_S3_DNS_BUCKET_NAMES to any value
+# your tests may fail unless you have DNS entry for the bucket name
+# e.g 127.0.0.1 net-amazon-s3-test-test.localhost
+
+my $dns_bucket_names
+  = ( $host && !exists $ENV{AMAZON_S3_DNS_BUCKET_NAMES} ) ? 0 : 1;
+
+my $aws_access_key_id     = $ENV{'AWS_ACCESS_KEY_ID'};
+my $aws_secret_access_key = $ENV{'AWS_ACCESS_KEY_SECRET'};
+my $token                 = $ENV{'AWS_SESSION_TOKEN'};
+
+if ( !$ENV{'AMAZON_S3_EXPENSIVE_TESTS'} ) {
+  plan skip_all => 'Testing this module for real costs money.';
+} ## end if ( !$ENV{'AMAZON_S3_EXPENSIVE_TESTS'...})
+else {
+  plan tests => 7;
+}
+
+use_ok('Amazon::S3');
+use_ok('Amazon::S3::Bucket');
+
+my $s3;
+
+if ( $ENV{AMAZON_S3_CREDENTIALS} ) {
+  require Amazon::Credentials;
+
+  $s3 = Amazon::S3->new(
+    { credentials      => Amazon::Credentials->new,
+      host             => $host,
+      secure           => $secure,
+      dns_bucket_names => $dns_bucket_names,
+      level            => $ENV{DEBUG} ? 'trace' : 'error',
+    }
+  );
+  ( $aws_access_key_id, $aws_secret_access_key, $token )
+    = $s3->get_credentials;
+} ## end if ( $ENV{AMAZON_S3_CREDENTIALS...})
+else {
+  $s3 = Amazon::S3->new(
+    { aws_access_key_id     => $aws_access_key_id,
+      aws_secret_access_key => $aws_secret_access_key,
+      token                 => $token,
+      host                  => $host,
+      secure                => $secure,
+      dns_bucket_names      => $dns_bucket_names,
+      level                 => $ENV{DEBUG} ? 'trace' : 'error',
+    }
+  );
+} ## end else [ if ( $ENV{AMAZON_S3_CREDENTIALS...})]
+
+sub create_bucket {
+  my ($bucket_name) = @_;
+
+  $bucket_name = '/' . $bucket_name;
+  my $bucket_obj
+    = eval { return $s3->add_bucket( { bucket => $bucket_name } ); };
+
+  return $bucket_obj;
+}
+
+my $bucket_obj = create_bucket sprintf 'net-amazon-s3-test-%s',
+  lc $aws_access_key_id;
+
+ok( ref $bucket_obj, 'created bucket' );
+
+if ( $EVAL_ERROR || !$bucket_obj ) {
+  BAIL_OUT( $s3->err . ": " . $s3->errstr );
+} ## end if ( $EVAL_ERROR || !$bucket_obj)
+
+subtest 'multipart-manual' => sub {
+  my $key = 'big-object-1';
+
+  my $id = $bucket_obj->initiate_multipart_upload($key);
+
+  my $part_list = {};
+
+  my $part = 0;
+  my $data = 'x' x ( 1024 * 1024 * 5 ); # 5 MB part
+
+  my $etag
+    = $bucket_obj->upload_part_of_multipart_upload( $key, $id, ++$part, $data,
+    length $data );
+
+  $part_list->{$part} = $etag;
+
+  $bucket_obj->complete_multipart_upload( $key, $id, $part_list );
+
+  my $head = $bucket_obj->head_key($key);
+
+  ok( $head, 'uploaded file' );
+
+  ok( $head->{content_length} == 5 * 1024 * 1024, 'uploaded 1 part' )
+    or diag( Dumper( [$head] ) );
+
+  ok( $bucket_obj->delete_key($key) );
+};
+
+subtest 'multipart-file' => sub {
+  my ( $fh, $file ) = tempfile();
+
+  my $buffer = 'x' x ( 1024 * 1024 );
+
+  # 11MB
+  foreach ( 0 .. 10 ) {
+    $fh->syswrite($buffer);
+  }
+
+  $fh->close;
+
+  if ( !open( $fh, '<', $file ) ) {
+    carp "could not open $file after writing";
+
+    return;
+  }
+
+  my $key = 'big-object-2';
+
+  $bucket_obj->upload_multipart_object( fh => $fh, key => $key );
+
+  close $fh;
+
+  my $head = $bucket_obj->head_key($key);
+
+  ok( $head, 'uploaded file' );
+
+  isa_ok( $head, 'HASH', 'head is a hash' );
+
+  ok( $head->{content_length} == 11 * 1024 * 1024, 'uploaded all parts' );
+
+  $bucket_obj->delete_key($key);
+
+  unlink $file;
+};
+
+subtest 'multipart-2-parts' => sub {
+  my $length = 1024 * 1024 * 7;
+
+  my $data = 'x' x $length;
+
+  my $key = 'big-object-3';
+
+  $bucket_obj->upload_multipart_object(
+    key  => $key,
+    data => $data
+  );
+
+  my $head = $bucket_obj->head_key($key);
+
+  isa_ok( $head, 'HASH', 'head is a hash' );
+
+  ok( $head, 'uploaded data' );
+
+  ok( $head->{content_length} == $length, 'uploaded all parts' );
+
+  $bucket_obj->delete_key($key);
+};
+
+subtest 'multipart-callback' => sub {
+  my $key = 'big-object-4';
+
+  my @part = ( 5, 5, 5, 1 );
+  my $size;
+
+  $bucket_obj->upload_multipart_object(
+    key      => $key,
+    callback => sub {
+      return ( q{}, 0 ) unless @part;
+
+      my $length = shift @part;
+      $length *= 1024 * 1024;
+
+      $size += $length;
+
+      my $data = 'x' x $length;
+
+      return ( \$data, $length );
+    }
+  );
+
+  my $head = $bucket_obj->head_key($key);
+
+  isa_ok( $head, 'HASH', 'head is a hash' );
+
+  ok( $head, 'uploaded data' );
+
+  ok( $head->{content_length} == $size, 'uploaded all parts' );
+
+  $bucket_obj->delete_key($key);
+};
+
+$bucket_obj->delete_bucket()
+  or diag( $s3->errstr );
+

--- a/src/main/perl/t/06-list-multipart-uploads.t
+++ b/src/main/perl/t/06-list-multipart-uploads.t
@@ -1,0 +1,198 @@
+#!/usr/bin/perl -w
+
+## no critic
+
+use warnings;
+use strict;
+
+use lib 'lib';
+
+use Carp;
+
+use Data::Dumper;
+use Digest::MD5::File qw(file_md5_hex);
+use English qw{-no_match_vars};
+use File::Temp qw{ tempfile };
+use Test::More;
+use XML::LibXML::Simple qw{XMLin};
+
+my $host;
+
+if ( exists $ENV{AMAZON_S3_LOCALSTACK} ) {
+  $host = 'localhost:4566';
+
+  $ENV{'AWS_ACCESS_KEY_ID'}     = 'test';
+  $ENV{'AWS_ACCESS_KEY_SECRET'} = 'test';
+
+  $ENV{'AMAZON_S3_EXPENSIVE_TESTS'} = 1;
+
+} ## end if ( exists $ENV{AMAZON_S3_LOCALSTACK...})
+else {
+  $host = $ENV{AMAZON_S3_HOST};
+} ## end else [ if ( exists $ENV{AMAZON_S3_LOCALSTACK...})]
+
+my $secure = $host ? 0 : 1;
+
+# do not use DNS bucket names for testing if a mocking service is used
+# override this by setting AMAZON_S3_DNS_BUCKET_NAMES to any value
+# your tests may fail unless you have DNS entry for the bucket name
+# e.g 127.0.0.1 net-amazon-s3-test-test.localhost
+
+my $dns_bucket_names
+  = ( $host && !exists $ENV{AMAZON_S3_DNS_BUCKET_NAMES} ) ? 0 : 1;
+
+my $aws_access_key_id     = $ENV{'AWS_ACCESS_KEY_ID'};
+my $aws_secret_access_key = $ENV{'AWS_ACCESS_KEY_SECRET'};
+my $token                 = $ENV{'AWS_SESSION_TOKEN'};
+
+if ( !$ENV{'AMAZON_S3_EXPENSIVE_TESTS'} ) {
+  plan skip_all => 'Testing this module for real costs money.';
+} ## end if ( !$ENV{'AMAZON_S3_EXPENSIVE_TESTS'...})
+else {
+  plan tests => 6;
+}
+
+use_ok('Amazon::S3');
+use_ok('Amazon::S3::Bucket');
+
+my $s3;
+
+if ( $ENV{AMAZON_S3_CREDENTIALS} ) {
+  require Amazon::Credentials;
+
+  $s3 = Amazon::S3->new(
+    { credentials      => Amazon::Credentials->new,
+      host             => $host,
+      secure           => $secure,
+      dns_bucket_names => $dns_bucket_names,
+      level            => $ENV{DEBUG} ? 'trace' : 'error',
+    }
+  );
+  ( $aws_access_key_id, $aws_secret_access_key, $token )
+    = $s3->get_credentials;
+} ## end if ( $ENV{AMAZON_S3_CREDENTIALS...})
+else {
+  $s3 = Amazon::S3->new(
+    { aws_access_key_id     => $aws_access_key_id,
+      aws_secret_access_key => $aws_secret_access_key,
+      token                 => $token,
+      host                  => $host,
+      secure                => $secure,
+      dns_bucket_names      => $dns_bucket_names,
+      level                 => $ENV{DEBUG} ? 'trace' : 'error',
+    }
+  );
+} ## end else [ if ( $ENV{AMAZON_S3_CREDENTIALS...})]
+
+sub list_multipart_uploads {
+  my ($bucket_obj) = @_;
+
+  my $xml = $bucket_obj->list_multipart_uploads;
+
+  ok( $xml =~ /^</xms, 'is xml result' );
+
+  my $uploads = XMLin( $xml, KeepRoot => 1 );
+
+  isa_ok( $uploads, 'HASH', 'made a hash object' )
+    or diag($uploads);
+
+  ok( defined $uploads->{ListMultipartUploadsResult},
+    'looks like a results object' )
+    or diag($xml);
+
+  my $upload_list = $uploads->{ListMultipartUploadsResult}->{Upload};
+
+  return $upload_list;
+}
+
+########################################################################
+sub partial_upload {
+########################################################################
+  my ( $key, $bucket_obj, $size_in_mb ) = @_;
+
+  my $id     = $bucket_obj->initiate_multipart_upload($key);
+  my $length = ( $size_in_mb || 5 ) * 1024 * 1024;
+
+  my $data = 'x' x $length;
+
+  my $etag
+    = $bucket_obj->upload_part_of_multipart_upload( $key, $id, 1, $data,
+    $length );
+
+  return $id;
+}
+
+########################################################################
+sub create_bucket {
+########################################################################
+  my ($bucket_name) = @_;
+
+  $bucket_name = '/' . $bucket_name;
+  my $bucket_obj
+    = eval { return $s3->add_bucket( { bucket => $bucket_name } ); };
+
+  return $bucket_obj;
+}
+
+my $bucket_name = sprintf 'net-amazon-s3-test-%s', lc $aws_access_key_id;
+my $bucket_obj  = create_bucket $bucket_name;
+
+ok( ref $bucket_obj, 'created bucket - ' . $bucket_name );
+
+if ( $EVAL_ERROR || !$bucket_obj ) {
+  BAIL_OUT( $s3->err . ": " . $s3->errstr );
+} ## end if ( $EVAL_ERROR || !$bucket_obj)
+
+my $id;
+my $key = 'big-object-1';
+
+subtest 'list-multipart-uploads' => sub {
+
+  my $upload_list = list_multipart_uploads($bucket_obj);
+  ok( !defined $upload_list, 'no in-progress uploads' )
+    or diag( Dumper( [$upload_list] ) );
+
+  $id = partial_upload( $key, $bucket_obj );
+
+  $upload_list = list_multipart_uploads($bucket_obj);
+
+  ok( $upload_list->{UploadId} eq $id, 'UploadId eq $id' );
+};
+
+subtest 'abort-multipart-upload' => sub {
+
+  $bucket_obj->abort_multipart_upload( $key, $id );
+
+  my $upload_list = list_multipart_uploads($bucket_obj);
+
+  ok( !defined $upload_list, 'aborted upload' );
+};
+
+subtest 'abort-on-error' => sub {
+  my $id = $bucket_obj->initiate_multipart_upload($key);
+
+  my $part_list = {};
+
+  my $part = 0;
+  my $data = 'x' x ( 1024 * 1024 * 1 ); # should be too small
+
+  # do this twice...
+  foreach ( 0 .. 1 ) {
+    my $etag
+      = $bucket_obj->upload_part_of_multipart_upload( $key, $id, ++$part,
+      $data, length $data );
+
+    $part_list->{$part} = $etag;
+  }
+
+  eval { $bucket_obj->complete_multipart_upload( $key, $id, $part_list ); };
+
+  ok( $EVAL_ERROR =~ /Bad Request/, 'abort-on-error successful' )
+    or diag( Dumper( [ $EVAL_ERROR, $id ] ) );
+
+  $bucket_obj->abort_multipart_upload( $key, $id );
+};
+
+$bucket_obj->delete_bucket()
+  or diag( $s3->errstr );
+


### PR DESCRIPTION
This version assumes that bucket operations require that the region of the bucket be considered when signing requests.  The region of the bucket is now stored as part of the bucket object's attributes.  The region can be passed in when the bucket is created or the region will be determined for the caller using the GetBucketLocation API call.

* allow region to be passed to bucket object constructor
* add new unit tests for multipart uploads
* updated error handling when `complete_multipart_upload()` calls fail
* documentation for multipart upload methods
* new convenience method for multipart uploads - `upload_multipart_object()`
* new convenience method `get_bucket_location()`