### PR TITLE
Small fix for error when retrieving keys with charset spec in content-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ managing Amazon S3 buckets and keys.
 
 # DESCRIPTION
 
-This documentation refers to version 0.65.
+This documentation refers to version 2.0.1.
 
 `Amazon::S3` provides a portable client interface to Amazon Simple
 Storage System (S3).

--- a/src/main/perl/lib/Amazon/S3/Bucket.pm.in
+++ b/src/main/perl/lib/Amazon/S3/Bucket.pm.in
@@ -685,7 +685,7 @@ sub _get_key {
 
   my $retval = {
     content_length => ( $response->content_length || 0 ),
-    content_type   => $response->content_type,
+    content_type   => scalar $response->content_type,
     etag           => $etag,
     value          => ( $response->content // $EMPTY ),
     content_range  => ( $response->header('Content-Range') || $EMPTY ),


### PR DESCRIPTION
At least on MinIO it can happen that documents have not just a simple content type like `text/html` but a multipart one like `text/html; charset="utf-8"`. In this case, `HTTP::Headers->content_type` says:

>  potential parameters will be chopped off and returned as a separate  value if in an array context.

This leads to "odd number of elements in anonymous hash" warnings and a failed get_keys call.
Forcing scalar context fixes it.