### PR TITLE
 Fixed a bug where encryption was impossible in special cases

### DIFF
--- a/src/main/perl/lib/Amazon/S3.pm.in
+++ b/src/main/perl/lib/Amazon/S3.pm.in
@@ -203,11 +203,11 @@ sub use_express_one_zone {
           return md5_hex( rand $PID );
         }
       };
+
+      return $text if $EVAL_ERROR;
     }
 
-    if ( !$encryption_key || $EVAL_ERROR ) {
-      return $text;
-    }
+    return $text if !$encryption_key;
 
     my $cipher = Crypt::CBC->new(
       -pass        => $encryption_key,


### PR DESCRIPTION
Fix catch not expected error bug

If not execute `eval` then not update `$EVAL_ERROR`.
And `_encrypt` is not encrypt if  existing `$EVAL_ERROR` and `$encryption_key`.

`$EVAL_ERROR` have to check when immediately after eval.


```perl
use Amazon::S3;
sub s3 {
 Amazon::S3->new(
    {   aws_access_key_id     => 'xxx',
        aws_secret_access_key => 'yyy',
        retry                 => 1
    }
  );
}

my $s3;
$s3 = s3(); # no problem when `$encryption_key` isn't defined
eval { die 'something...' }; # $EVAL_ERROR updated
$s3 = s3(); # not encrypt AWS keys 

use Test2::V0;
is $s3->aws_access_key_id, 'xxx';
is $s3->aws_secret_access_key, 'yyy';
done_testing;
```