### PR TITLE
maybe better region support

### DIFF
--- a/src/main/perl/lib/Amazon/S3.pm.in
+++ b/src/main/perl/lib/Amazon/S3.pm.in
@@ -640,17 +640,25 @@ sub list_bucket {
 ########################################################################
   my ( $self, $conf ) = @_;
 
-  my $bucket = delete $conf->{bucket};
-
-  croak 'must specify bucket'
-    if !$bucket;
-
   $conf //= {};
+
+  my $bucket;
+  my $region;
+  my $headers;
+
+  if ( eval { return $conf->isa('Amazon::S3::Bucket'); } ) {
+    $bucket = $conf->bucket;
+    $region = $conf->region;
+    $conf = {};
+  }
+  else {
+    $bucket  = delete $conf->{bucket};
+    $region  = delete $conf->{region} || $self->get_bucket_location($bucket);
+    $headers = delete $conf->{headers};
+  }
 
   my $bucket_list; # return this
   my $path = $bucket . $SLASH;
-
-  my $headers = delete $conf->{headers};
 
   my $list_type = $conf->{'list-type'} // '1';
 
@@ -685,7 +693,7 @@ sub list_bucket {
     { method  => 'GET',
       path    => $path,
       headers => $headers // {}, # { 'Content-Length' => 0 },
-      region  => $self->region,
+      region  => $region,
     },
   );
 
@@ -859,17 +867,25 @@ sub list_object_versions {
 ########################################################################
   my ( $self, $conf ) = @_;
 
-  my $bucket = delete $conf->{bucket};
+  $conf //= {};
 
-  die 'no bucket'
-    if !$bucket;
+  my $bucket;
+  my $region;
+  my $headers;
 
-  my $headers = delete $conf->{headers};
+  if ( eval { return $conf->isa('Amazon::S3::Bucket'); } ) {
+    $bucket = $conf->bucket;
+    $region = $conf->region;
+    $conf = {};
+  }
+  else {
+    $bucket  = delete $conf->{bucket};
+    $region  = delete $conf->{region} || $self->get_bucket_location($bucket);
+    $headers = delete $conf->{headers};
+  }
 
   croak 'must specify bucket'
     if !$bucket;
-
-  $conf ||= {};
 
   my ( $marker, $next_marker, $query_next )
     = @{ $LIST_OBJECT_MARKERS{'3'} };
@@ -895,7 +911,7 @@ sub list_object_versions {
     { method  => 'GET',
       path    => $path,
       headers => $headers // {},
-      region  => $self->region,
+      region  => $region,
     },
   );
 

--- a/src/main/perl/lib/Amazon/S3/Bucket.pm.in
+++ b/src/main/perl/lib/Amazon/S3/Bucket.pm.in
@@ -983,6 +983,7 @@ sub list {
   $conf ||= {};
 
   $conf->{bucket} = $self->bucket;
+  $conf->{region} //= $self->region;
 
   return $self->account->list_bucket($conf);
 }
@@ -995,6 +996,7 @@ sub list_all_v2 {
   $conf //= {};
 
   $conf->{bucket} = $self->bucket;
+  $conf->{region} //= $self->region;
 
   return $self->account->list_bucket_all_v2($conf);
 }
@@ -1007,6 +1009,7 @@ sub list_all {
   $conf //= {};
 
   $conf->{bucket} = $self->bucket;
+  $conf->{region} //= $self->region;
 
   return $self->account->list_bucket_all($conf);
 }


### PR DESCRIPTION
previously, buckets outside us-west-1 couldn't be reliably listed unless the whole `Amazon::S3` object was set to the correct region, because the `list_bucket` &c methods always used the `Amazon::S3`'s object region, not the bucket's region

this commit:

* copies the logic from `delete_bucket` into the various `list_*` methods
* passes the bucket's region to the `list_*` methods, saving some requests

I have not done a very thorough testing of this, but it seems to work.